### PR TITLE
fix OffsetOnTransform.m_initialLocalMatrix

### DIFF
--- a/Assets/UniVRM-1.0/Components/LookAt/OffsetOnTransform.cs
+++ b/Assets/UniVRM-1.0/Components/LookAt/OffsetOnTransform.cs
@@ -47,7 +47,8 @@ namespace UniVRM10
         {
             var coordinate = new OffsetOnTransform
             {
-                Transform = transform
+                Transform = transform,
+                m_initialLocalMatrix = Matrix4x4.identity,
             };
 
             if (transform != null)


### PR DESCRIPTION
* 元々、正規化されていないモデルの初期値を記録することを意図されていた。Matrix4x4.identity でよい。