### PR TITLE
Rendererを構築時に非表示にするオプション

### DIFF
--- a/Assets/UniVRM-1.0/Scenes/Sample.cs
+++ b/Assets/UniVRM-1.0/Scenes/Sample.cs
@@ -9,14 +9,20 @@ public class Sample : MonoBehaviour
     [SerializeField]
     string m_vrmPath = "Tests/Models/Alicia_vrm-0.51/AliciaSolid_vrm-0.51.vrm";
 
-
     static UniVRM10.ModelAsset Import(byte[] bytes, FileInfo path)
     {
         var model = UniVRM10.VrmLoader.CreateVrmModel(bytes, path);
 
         // UniVRM-0.XXのコンポーネントを構築する
         var importer = new UniVRM10.RuntimeUnityBuilder();
-        var assets = importer.ToUnityAsset(model);
+        var assets = importer.ToUnityAsset(model, showMesh: false);
+
+        // showRenderer = false のときに後で表示する例
+        foreach(var renderer in assets.Renderers)
+        {
+            renderer.enabled = true;
+        }
+
         UniVRM10.ComponentBuilder.Build10(model, importer, assets);
 
         return assets;

--- a/Assets/UniVRM-1.0/UnityBuilder/ModelAsset.cs
+++ b/Assets/UniVRM-1.0/UnityBuilder/ModelAsset.cs
@@ -16,6 +16,7 @@ namespace UniVRM10
         public List<Texture2D> Textures = new List<Texture2D>();
         public List<Material> Materials = new List<Material>();
         public List<Mesh> Meshes = new List<Mesh>();
+        public List<Renderer> Renderers = new List<Renderer>();
 
         public ModelMap Map;
         public List<ScriptableObject> ScriptableObjects = new List<ScriptableObject>();

--- a/Assets/UniVRM-1.0/UnityBuilder/RuntimeUnityBuilder.cs
+++ b/Assets/UniVRM-1.0/UnityBuilder/RuntimeUnityBuilder.cs
@@ -26,7 +26,7 @@ namespace UniVRM10
         GameObject IUnityBuilder.Root => Root;
 
 
-        public ModelAsset ToUnityAsset(VrmLib.Model model)
+        public ModelAsset ToUnityAsset(VrmLib.Model model, bool showMesh = true)
         {
             var modelAsset = new ModelAsset();
             CreateTextureAsset(model, modelAsset);
@@ -41,7 +41,9 @@ namespace UniVRM10
             // renderer
             foreach (var (mesh, renderer) in CreateRendererAsset(Nodes, Meshes, Materials))
             {
+                renderer.enabled = showMesh;
                 Renderers.Add(mesh, renderer);
+                modelAsset.Renderers.Add(renderer);
             }
 
             // humanoid


### PR DESCRIPTION
#29 

* RuntimeUnityBuilder.ToUnityにRendererの初期状態を選択できるオプション(showMesh)を追加
* ロード後にまとめてRendererにアクセスできる(ModelAsset.Renderers)を追加

逆に ModelAsset.Renderers から非表示にしてもよいのだけど、
あとで、ToUnityAsync を作った場合そっちでは初期値が必要になるので。
