### PR TITLE
mesh indexを、meshを保持するnodeのindexに変更する

### DIFF
--- a/Assets/ProtobufSerializer/ProtobufSerializer/BlendShapeAdapter.cs
+++ b/Assets/ProtobufSerializer/ProtobufSerializer/BlendShapeAdapter.cs
@@ -8,7 +8,7 @@ namespace Vrm10
 {
     public static class BlendShapeAdapter
     {
-        public static BlendShapeManager FromGltf(this VrmProtobuf.BlendShape master, List<MeshGroup> meshes, List<Material> materials)
+        public static BlendShapeManager FromGltf(this VrmProtobuf.BlendShape master, List<Node> nodes, List<Material> materials)
         {
             var manager = new BlendShapeManager();
             manager.BlendShapeList.AddRange(master.BlendShapeGroups.Select(x =>
@@ -19,9 +19,9 @@ namespace Vrm10
                 expression.BlendShapeValues.AddRange(
                     x.Binds.Select(y =>
                     {
-                        var group = meshes[y.Mesh];
-                        var blendShapeName = group.Meshes[0].MorphTargets[y.Index].Name;
-                        var value = new BlendShapeBindValue(group, blendShapeName, y.Weight);
+                        var node = nodes[y.Node];
+                        var blendShapeName = node.Mesh.MorphTargets[y.Index].Name;
+                        var value = new BlendShapeBindValue(node, blendShapeName, y.Weight);
                         return value;
                     }));
                 expression.MaterialValues.AddRange(
@@ -41,11 +41,11 @@ namespace Vrm10
             return manager;
         }
 
-        public static VrmProtobuf.BlendShapeGroup.Types.BlendShapeBind ToGltf(this BlendShapeBindValue self, List<MeshGroup> meshes)
+        public static VrmProtobuf.BlendShapeGroup.Types.BlendShapeBind ToGltf(this BlendShapeBindValue self, List<Node> nodes)
         {
             var name = self.Name;
             var value = self.Value;
-            var index = self.Mesh.Meshes[0].MorphTargets.FindIndex(x => x.Name == name);
+            var index = self.Node.Mesh.MorphTargets.FindIndex(x => x.Name == name);
             if (index < 0)
             {
                 throw new IndexOutOfRangeException(string.Format("MorphTargetName {0} is not found", name));
@@ -53,8 +53,8 @@ namespace Vrm10
 
             return new VrmProtobuf.BlendShapeGroup.Types.BlendShapeBind
             {
-                Mesh = meshes.IndexOfThrow(self.Mesh),
-                Index = self.Mesh.Meshes[0].MorphTargets.FindIndex(x => x.Name == name),
+                Node = nodes.IndexOfThrow(self.Node),
+                Index = self.Node.Mesh.MorphTargets.FindIndex(x => x.Name == name),
                 Weight = value,
             };
         }
@@ -81,7 +81,7 @@ namespace Vrm10
             return m;
         }
 
-        public static VrmProtobuf.BlendShapeGroup ToGltf(this BlendShape x, List<MeshGroup> meshes, List<Material> materials)
+        public static VrmProtobuf.BlendShapeGroup ToGltf(this BlendShape x, List<Node> nodes, List<Material> materials)
         {
             var g = new VrmProtobuf.BlendShapeGroup
             {
@@ -94,7 +94,7 @@ namespace Vrm10
             };
             foreach (var y in x.BlendShapeValues)
             {
-                g.Binds.Add(y.ToGltf(meshes));
+                g.Binds.Add(y.ToGltf(nodes));
             }
             foreach (var y in x.MaterialValues)
             {
@@ -103,7 +103,7 @@ namespace Vrm10
             return g;
         }
 
-        public static VrmProtobuf.BlendShape ToGltf(this BlendShapeManager src, List<MeshGroup> meshes, List<Material> materials)
+        public static VrmProtobuf.BlendShape ToGltf(this BlendShapeManager src, List<Node> nodes, List<Material> materials)
         {
             var blendShape = new VrmProtobuf.BlendShape
             {
@@ -112,7 +112,7 @@ namespace Vrm10
             {
                 foreach (var x in src.BlendShapeList)
                 {
-                    blendShape.BlendShapeGroups.Add(x.ToGltf(meshes, materials));
+                    blendShape.BlendShapeGroups.Add(x.ToGltf(nodes, materials));
                 }
             }
             return blendShape;

--- a/Assets/ProtobufSerializer/ProtobufSerializer/FirstPersonAdapter.cs
+++ b/Assets/ProtobufSerializer/ProtobufSerializer/FirstPersonAdapter.cs
@@ -20,15 +20,15 @@ namespace Vrm10
             throw new NotImplementedException();
         }
 
-        public static FirstPerson FromGltf(this VrmProtobuf.FirstPerson fp, List<Node> nodes, List<MeshGroup> meshes)
+        public static FirstPerson FromGltf(this VrmProtobuf.FirstPerson fp, List<Node> nodes)
         {
             var self = new FirstPerson();
             // self.m_offset = fp.FirstPersonBoneOffset.ToVector3();
             self.Annotations.AddRange(fp.MeshAnnotations
-                .Select(x => new FirstPersonMeshAnnotation(meshes[x.Mesh], x.FirstPersonType.FromGltf())));
+                .Select(x => new FirstPersonMeshAnnotation(nodes[x.Node], x.FirstPersonType.FromGltf())));
             return self;
         }
-        public static VrmProtobuf.FirstPerson ToGltf(this FirstPerson self, List<Node> nodes, List<MeshGroup> meshes)
+        public static VrmProtobuf.FirstPerson ToGltf(this FirstPerson self, List<Node> nodes)
         {
             if (self == null)
             {
@@ -44,7 +44,7 @@ namespace Vrm10
             {
                 firstPerson.MeshAnnotations.Add(new VrmProtobuf.FirstPerson.Types.MeshAnnotation
                 {
-                    Mesh = meshes.IndexOfThrow(x.Mesh),
+                    Node = nodes.IndexOfThrow(x.Node),
                     FirstPersonType = (VrmProtobuf.FirstPerson.Types.MeshAnnotation.Types.FirstPersonType)x.FirstPersonFlag,
                 });
             }

--- a/Assets/ProtobufSerializer/ProtobufSerializer/Vrm10Exporter.cs
+++ b/Assets/ProtobufSerializer/ProtobufSerializer/Vrm10Exporter.cs
@@ -229,9 +229,9 @@ namespace Vrm10
             }
         }
 
-        public void ExportVrmBlendShape(BlendShapeManager src, List<MeshGroup> meshes, List<Material> materials)
+        public void ExportVrmBlendShape(BlendShapeManager src, List<MeshGroup> _, List<Material> materials, List<Node> nodes)
         {
-            Gltf.Extensions.VRMCVrm.BlendShape = src.ToGltf(meshes, materials);
+            Gltf.Extensions.VRMCVrm.BlendShape = src.ToGltf(nodes, materials);
         }
 
         public void ExportVrmSpringBone(SpringBoneManager springBone, List<Node> nodes)
@@ -241,7 +241,7 @@ namespace Vrm10
 
         public void ExportVrmFirstPersonAndLookAt(FirstPerson firstPerson, LookAt lookat, List<MeshGroup> meshes, List<Node> nodes)
         {
-            Gltf.Extensions.VRMCVrm.FirstPerson = firstPerson.ToGltf(nodes, meshes);
+            Gltf.Extensions.VRMCVrm.FirstPerson = firstPerson.ToGltf(nodes);
             Gltf.Extensions.VRMCVrm.LookAt = lookat.ToGltf();
         }
 

--- a/Assets/ProtobufSerializer/ProtobufSerializer/Vrm10Storage.cs
+++ b/Assets/ProtobufSerializer/ProtobufSerializer/Vrm10Storage.cs
@@ -434,10 +434,10 @@ namespace Vrm10
 
         private Texture.ColorSpaceTypes GetTextureColorSpaceType(int textureIndex)
         {
-            foreach(var material in Gltf.Materials)
+            foreach (var material in Gltf.Materials)
             {
                 // mtoon
-                if(material.Extensions != null && material.Extensions.VRMCMaterialsMtoon != null)
+                if (material.Extensions != null && material.Extensions.VRMCMaterialsMtoon != null)
                 {
                     var mtoon = material.Extensions.VRMCMaterialsMtoon;
                     if (mtoon.LitMultiplyTexture == textureIndex) return Texture.ColorSpaceTypes.Srgb;
@@ -452,7 +452,7 @@ namespace Vrm10
                     if (mtoon.NormalTexture == textureIndex) return Texture.ColorSpaceTypes.Linear;
                 }
                 // unlit
-                else if(material.Extensions != null && material.Extensions.KHRMaterialsUnlit != null)
+                else if (material.Extensions != null && material.Extensions.KHRMaterialsUnlit != null)
                 {
                     if (material.PbrMetallicRoughness.BaseColorTexture.Index == textureIndex) return Texture.ColorSpaceTypes.Srgb;
                 }
@@ -480,7 +480,7 @@ namespace Vrm10
             ? Gltf.Samplers[texture.Sampler.Value]
             : new VrmProtobuf.Sampler()
             ;
-            
+
             if (textureType.Item1 == Texture.TextureTypes.MetallicRoughness && textureType.Item2.PbrMetallicRoughness != null)
             {
                 var roughnessFactor = textureType.Item2.PbrMetallicRoughness.RoughnessFactor;
@@ -577,14 +577,14 @@ namespace Vrm10
             }
         }
 
-        public BlendShapeManager CreateVrmBlendShape(List<MeshGroup> meshGroups, List<Material> materials)
+        public BlendShapeManager CreateVrmBlendShape(List<MeshGroup> _, List<Material> materials, List<Node> nodes)
         {
             var gltfVrm = Gltf.Extensions.VRMCVrm;
             if (gltfVrm.BlendShape != null
                 && gltfVrm.BlendShape.BlendShapeGroups != null
                 && gltfVrm.BlendShape.BlendShapeGroups.Any())
             {
-                return gltfVrm.BlendShape.FromGltf(meshGroups, materials);
+                return gltfVrm.BlendShape.FromGltf(nodes, materials);
             }
 
             return null;
@@ -638,7 +638,7 @@ namespace Vrm10
             {
                 return null;
             }
-            return gltfVrm.FirstPerson.FromGltf(nodes, meshGroups);
+            return gltfVrm.FirstPerson.FromGltf(nodes);
         }
 
         public LookAt CreateVrmLookAt()

--- a/Assets/ProtobufSerializer/VrmProtobuf/VRM/v1.0/src/BlendShape.cs
+++ b/Assets/ProtobufSerializer/VrmProtobuf/VRM/v1.0/src/BlendShape.cs
@@ -36,7 +36,7 @@ namespace VrmProtobuf {
             "LwoLaWdub3JlQmxpbmsYCCABKAsyGi5nb29nbGUucHJvdG9idWYuQm9vbFZh",
             "bHVlEjAKDGlnbm9yZUxvb2tBdBgJIAEoCzIaLmdvb2dsZS5wcm90b2J1Zi5C",
             "b29sVmFsdWUSLwoLaWdub3JlTW91dGgYCiABKAsyGi5nb29nbGUucHJvdG9i",
-            "dWYuQm9vbFZhbHVlGj0KDkJsZW5kU2hhcGVCaW5kEgwKBG1lc2gYASABKAUS",
+            "dWYuQm9vbFZhbHVlGj0KDkJsZW5kU2hhcGVCaW5kEgwKBG5vZGUYASABKAUS",
             "DQoFaW5kZXgYAiABKAUSDgoGd2VpZ2h0GAMgASgCGnUKDU1hdGVyaWFsVmFs",
             "dWUSEAoIbWF0ZXJpYWwYASABKAUSPQoEdHlwZRgCIAEoDjIvLlZybVByb3Rv",
             "YnVmLkJsZW5kU2hhcGVHcm91cC5NYXRlcmlhbFZhbHVlVHlwZXMSEwoLdGFy",
@@ -51,7 +51,7 @@ namespace VrmProtobuf {
           new pbr::FileDescriptor[] { global::Google.Protobuf.WellKnownTypes.WrappersReflection.Descriptor, },
           new pbr::GeneratedClrTypeInfo(null, null, new pbr::GeneratedClrTypeInfo[] {
             new pbr::GeneratedClrTypeInfo(typeof(global::VrmProtobuf.BlendShape), global::VrmProtobuf.BlendShape.Parser, new[]{ "BlendShapeGroups" }, null, null, null, null),
-            new pbr::GeneratedClrTypeInfo(typeof(global::VrmProtobuf.BlendShapeGroup), global::VrmProtobuf.BlendShapeGroup.Parser, new[]{ "Name", "Preset", "Binds", "MaterialValues", "IsBinary", "IgnoreBlink", "IgnoreLookAt", "IgnoreMouth" }, null, new[]{ typeof(global::VrmProtobuf.BlendShapeGroup.Types.BlendShapePreset), typeof(global::VrmProtobuf.BlendShapeGroup.Types.MaterialValueTypes) }, null, new pbr::GeneratedClrTypeInfo[] { new pbr::GeneratedClrTypeInfo(typeof(global::VrmProtobuf.BlendShapeGroup.Types.BlendShapeBind), global::VrmProtobuf.BlendShapeGroup.Types.BlendShapeBind.Parser, new[]{ "Mesh", "Index", "Weight" }, null, null, null, null),
+            new pbr::GeneratedClrTypeInfo(typeof(global::VrmProtobuf.BlendShapeGroup), global::VrmProtobuf.BlendShapeGroup.Parser, new[]{ "Name", "Preset", "Binds", "MaterialValues", "IsBinary", "IgnoreBlink", "IgnoreLookAt", "IgnoreMouth" }, null, new[]{ typeof(global::VrmProtobuf.BlendShapeGroup.Types.BlendShapePreset), typeof(global::VrmProtobuf.BlendShapeGroup.Types.MaterialValueTypes) }, null, new pbr::GeneratedClrTypeInfo[] { new pbr::GeneratedClrTypeInfo(typeof(global::VrmProtobuf.BlendShapeGroup.Types.BlendShapeBind), global::VrmProtobuf.BlendShapeGroup.Types.BlendShapeBind.Parser, new[]{ "Node", "Index", "Weight" }, null, null, null, null),
             new pbr::GeneratedClrTypeInfo(typeof(global::VrmProtobuf.BlendShapeGroup.Types.MaterialValue), global::VrmProtobuf.BlendShapeGroup.Types.MaterialValue.Parser, new[]{ "Material", "Type", "TargetValue" }, null, null, null, null)})
           }));
     }
@@ -591,7 +591,7 @@ namespace VrmProtobuf {
 
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
         public BlendShapeBind(BlendShapeBind other) : this() {
-          mesh_ = other.mesh_;
+          node_ = other.node_;
           index_ = other.index_;
           weight_ = other.weight_;
           _unknownFields = pb::UnknownFieldSet.Clone(other._unknownFields);
@@ -602,14 +602,14 @@ namespace VrmProtobuf {
           return new BlendShapeBind(this);
         }
 
-        /// <summary>Field number for the "mesh" field.</summary>
-        public const int MeshFieldNumber = 1;
-        private int mesh_;
+        /// <summary>Field number for the "node" field.</summary>
+        public const int NodeFieldNumber = 1;
+        private int node_;
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        public int Mesh {
-          get { return mesh_; }
+        public int Node {
+          get { return node_; }
           set {
-            mesh_ = value;
+            node_ = value;
           }
         }
 
@@ -648,7 +648,7 @@ namespace VrmProtobuf {
           if (ReferenceEquals(other, this)) {
             return true;
           }
-          if (Mesh != other.Mesh) return false;
+          if (Node != other.Node) return false;
           if (Index != other.Index) return false;
           if (!pbc::ProtobufEqualityComparers.BitwiseSingleEqualityComparer.Equals(Weight, other.Weight)) return false;
           return Equals(_unknownFields, other._unknownFields);
@@ -657,7 +657,7 @@ namespace VrmProtobuf {
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
         public override int GetHashCode() {
           int hash = 1;
-          if (Mesh != 0) hash ^= Mesh.GetHashCode();
+          if (Node != 0) hash ^= Node.GetHashCode();
           if (Index != 0) hash ^= Index.GetHashCode();
           if (Weight != 0F) hash ^= pbc::ProtobufEqualityComparers.BitwiseSingleEqualityComparer.GetHashCode(Weight);
           if (_unknownFields != null) {
@@ -673,9 +673,9 @@ namespace VrmProtobuf {
 
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
         public void WriteTo(pb::CodedOutputStream output) {
-          if (Mesh != 0) {
+          if (Node != 0) {
             output.WriteRawTag(8);
-            output.WriteInt32(Mesh);
+            output.WriteInt32(Node);
           }
           if (Index != 0) {
             output.WriteRawTag(16);
@@ -693,8 +693,8 @@ namespace VrmProtobuf {
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
         public int CalculateSize() {
           int size = 0;
-          if (Mesh != 0) {
-            size += 1 + pb::CodedOutputStream.ComputeInt32Size(Mesh);
+          if (Node != 0) {
+            size += 1 + pb::CodedOutputStream.ComputeInt32Size(Node);
           }
           if (Index != 0) {
             size += 1 + pb::CodedOutputStream.ComputeInt32Size(Index);
@@ -713,8 +713,8 @@ namespace VrmProtobuf {
           if (other == null) {
             return;
           }
-          if (other.Mesh != 0) {
-            Mesh = other.Mesh;
+          if (other.Node != 0) {
+            Node = other.Node;
           }
           if (other.Index != 0) {
             Index = other.Index;
@@ -734,7 +734,7 @@ namespace VrmProtobuf {
                 _unknownFields = pb::UnknownFieldSet.MergeFieldFrom(_unknownFields, input);
                 break;
               case 8: {
-                Mesh = input.ReadInt32();
+                Node = input.ReadInt32();
                 break;
               }
               case 16: {

--- a/Assets/ProtobufSerializer/VrmProtobuf/VRM/v1.0/src/FirstPerson.cs
+++ b/Assets/ProtobufSerializer/VrmProtobuf/VRM/v1.0/src/FirstPerson.cs
@@ -27,7 +27,7 @@ namespace VrmProtobuf {
             "ChFmaXJzdFBlcnNvbi5wcm90bxILVnJtUHJvdG9idWYaHmdvb2dsZS9wcm90",
             "b2J1Zi93cmFwcGVycy5wcm90byKTAgoLRmlyc3RQZXJzb24SQAoPbWVzaEFu",
             "bm90YXRpb25zGAEgAygLMicuVnJtUHJvdG9idWYuRmlyc3RQZXJzb24uTWVz",
-            "aEFubm90YXRpb24awQEKDk1lc2hBbm5vdGF0aW9uEgwKBG1lc2gYASABKAUS",
+            "aEFubm90YXRpb24awQEKDk1lc2hBbm5vdGF0aW9uEgwKBG5vZGUYASABKAUS",
             "UAoPZmlyc3RQZXJzb25UeXBlGAIgASgOMjcuVnJtUHJvdG9idWYuRmlyc3RQ",
             "ZXJzb24uTWVzaEFubm90YXRpb24uRmlyc3RQZXJzb25UeXBlIk8KD0ZpcnN0",
             "UGVyc29uVHlwZRIICgRhdXRvEAASCAoEYm90aBABEhMKD3RoaXJkUGVyc29u",
@@ -35,7 +35,7 @@ namespace VrmProtobuf {
       descriptor = pbr::FileDescriptor.FromGeneratedCode(descriptorData,
           new pbr::FileDescriptor[] { global::Google.Protobuf.WellKnownTypes.WrappersReflection.Descriptor, },
           new pbr::GeneratedClrTypeInfo(null, null, new pbr::GeneratedClrTypeInfo[] {
-            new pbr::GeneratedClrTypeInfo(typeof(global::VrmProtobuf.FirstPerson), global::VrmProtobuf.FirstPerson.Parser, new[]{ "MeshAnnotations" }, null, null, null, new pbr::GeneratedClrTypeInfo[] { new pbr::GeneratedClrTypeInfo(typeof(global::VrmProtobuf.FirstPerson.Types.MeshAnnotation), global::VrmProtobuf.FirstPerson.Types.MeshAnnotation.Parser, new[]{ "Mesh", "FirstPersonType" }, null, new[]{ typeof(global::VrmProtobuf.FirstPerson.Types.MeshAnnotation.Types.FirstPersonType) }, null, null)})
+            new pbr::GeneratedClrTypeInfo(typeof(global::VrmProtobuf.FirstPerson), global::VrmProtobuf.FirstPerson.Parser, new[]{ "MeshAnnotations" }, null, null, null, new pbr::GeneratedClrTypeInfo[] { new pbr::GeneratedClrTypeInfo(typeof(global::VrmProtobuf.FirstPerson.Types.MeshAnnotation), global::VrmProtobuf.FirstPerson.Types.MeshAnnotation.Parser, new[]{ "Node", "FirstPersonType" }, null, new[]{ typeof(global::VrmProtobuf.FirstPerson.Types.MeshAnnotation.Types.FirstPersonType) }, null, null)})
           }));
     }
     #endregion
@@ -196,7 +196,7 @@ namespace VrmProtobuf {
 
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
         public MeshAnnotation(MeshAnnotation other) : this() {
-          mesh_ = other.mesh_;
+          node_ = other.node_;
           firstPersonType_ = other.firstPersonType_;
           _unknownFields = pb::UnknownFieldSet.Clone(other._unknownFields);
         }
@@ -206,17 +206,17 @@ namespace VrmProtobuf {
           return new MeshAnnotation(this);
         }
 
-        /// <summary>Field number for the "mesh" field.</summary>
-        public const int MeshFieldNumber = 1;
-        private int mesh_;
+        /// <summary>Field number for the "node" field.</summary>
+        public const int NodeFieldNumber = 1;
+        private int node_;
         /// <summary>
         /// Specify mesh
         /// </summary>
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        public int Mesh {
-          get { return mesh_; }
+        public int Node {
+          get { return node_; }
           set {
-            mesh_ = value;
+            node_ = value;
           }
         }
 
@@ -247,7 +247,7 @@ namespace VrmProtobuf {
           if (ReferenceEquals(other, this)) {
             return true;
           }
-          if (Mesh != other.Mesh) return false;
+          if (Node != other.Node) return false;
           if (FirstPersonType != other.FirstPersonType) return false;
           return Equals(_unknownFields, other._unknownFields);
         }
@@ -255,7 +255,7 @@ namespace VrmProtobuf {
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
         public override int GetHashCode() {
           int hash = 1;
-          if (Mesh != 0) hash ^= Mesh.GetHashCode();
+          if (Node != 0) hash ^= Node.GetHashCode();
           if (FirstPersonType != global::VrmProtobuf.FirstPerson.Types.MeshAnnotation.Types.FirstPersonType.Auto) hash ^= FirstPersonType.GetHashCode();
           if (_unknownFields != null) {
             hash ^= _unknownFields.GetHashCode();
@@ -270,9 +270,9 @@ namespace VrmProtobuf {
 
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
         public void WriteTo(pb::CodedOutputStream output) {
-          if (Mesh != 0) {
+          if (Node != 0) {
             output.WriteRawTag(8);
-            output.WriteInt32(Mesh);
+            output.WriteInt32(Node);
           }
           if (FirstPersonType != global::VrmProtobuf.FirstPerson.Types.MeshAnnotation.Types.FirstPersonType.Auto) {
             output.WriteRawTag(16);
@@ -286,8 +286,8 @@ namespace VrmProtobuf {
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
         public int CalculateSize() {
           int size = 0;
-          if (Mesh != 0) {
-            size += 1 + pb::CodedOutputStream.ComputeInt32Size(Mesh);
+          if (Node != 0) {
+            size += 1 + pb::CodedOutputStream.ComputeInt32Size(Node);
           }
           if (FirstPersonType != global::VrmProtobuf.FirstPerson.Types.MeshAnnotation.Types.FirstPersonType.Auto) {
             size += 1 + pb::CodedOutputStream.ComputeEnumSize((int) FirstPersonType);
@@ -303,8 +303,8 @@ namespace VrmProtobuf {
           if (other == null) {
             return;
           }
-          if (other.Mesh != 0) {
-            Mesh = other.Mesh;
+          if (other.Node != 0) {
+            Node = other.Node;
           }
           if (other.FirstPersonType != global::VrmProtobuf.FirstPerson.Types.MeshAnnotation.Types.FirstPersonType.Auto) {
             FirstPersonType = other.FirstPersonType;
@@ -321,7 +321,7 @@ namespace VrmProtobuf {
                 _unknownFields = pb::UnknownFieldSet.MergeFieldFrom(_unknownFields, input);
                 break;
               case 8: {
-                Mesh = input.ReadInt32();
+                Node = input.ReadInt32();
                 break;
               }
               case 16: {

--- a/Assets/UniVRM-1.0/UnityBuilder/ComponentBuilder.cs
+++ b/Assets/UniVRM-1.0/UnityBuilder/ComponentBuilder.cs
@@ -30,12 +30,14 @@ namespace UniVRM10
 
         static UniVRM10.BlendShapeBinding Build10(this VrmLib.BlendShapeBindValue bind, IUnityBuilder loader)
         {
-            var mesh = loader.Meshes[bind.Mesh];
-            var transformMeshTable = loader.Root.transform.Traverse()
-                .Select(GetTransformAndMesh)
-                .Where(x => x.Item2 != null)
-                .ToDictionary(x => x.Item2, x => x.Item1);
-            var node = transformMeshTable[mesh];
+            var node = loader.Nodes[bind.Node].transform;
+            var mesh = loader.Meshes[bind.Node.MeshGroup];
+            // var transformMeshTable = loader.Root.transform.Traverse()
+            //     .Select(GetTransformAndMesh)
+            //     .Where(x => x.Item2 != null)
+            //     .ToDictionary(x => x.Item2, x => x.Item1);
+            // var node = transformMeshTable[mesh];
+            // var transform = loader.Nodes[node].transform;
             var relativePath = node.RelativePathFrom(loader.Root.transform);
 
             var names = new List<string>();
@@ -166,7 +168,7 @@ namespace UniVRM10
                 firstPerson.Renderers = model.Vrm.FirstPerson.Annotations.Select(x =>
                     new UniVRM10.VRMFirstPerson.RendererFirstPersonFlags()
                     {
-                        Renderer = asset.Map.Renderers[x.Mesh],
+                        Renderer = asset.Map.Renderers[x.Node.MeshGroup],
                         FirstPersonFlag = x.FirstPersonFlag
                     }
                     ).ToList();

--- a/Assets/UniVRM-1.0/VRMConverter/RuntimeVrmConverter.cs
+++ b/Assets/UniVRM-1.0/VRMConverter/RuntimeVrmConverter.cs
@@ -104,7 +104,7 @@ namespace UniVRM10
                 info = new VrmLib.TextureInfo(new VrmLib.ImageTexture(texture.name, sampler, image, colorSpace, textureType));
                 Textures.Add(texture, info);
 
-                if(Model != null)
+                if (Model != null)
                 {
                     Model.Images.Add(image);
                     Model.Textures.Add(info.Texture);
@@ -214,8 +214,9 @@ namespace UniVRM10
                                 names.Add(mesh.GetBlendShapeName(i));
                             }
 
+                            var node = Nodes[transform.gameObject];
                             var blendShapeValue = new VrmLib.BlendShapeBindValue(
-                                Meshes[mesh],
+                                node,
                                 names[value.Index],
                                 value.Weight
                                 );
@@ -247,11 +248,11 @@ namespace UniVRM10
                 var firstPersonComponent = root.GetComponent<UniVRM10.VRMFirstPerson>();
                 if (firstPersonComponent != null)
                 {
-                    foreach (var renderer in firstPersonComponent.Renderers)
+                    foreach (var annotation in firstPersonComponent.Renderers)
                     {
                         firstPerson.Annotations.Add(
-                            new VrmLib.FirstPersonMeshAnnotation(Meshes[renderer.SharedMesh],
-                            renderer.FirstPersonFlag)
+                            new VrmLib.FirstPersonMeshAnnotation(Nodes[annotation.Renderer.gameObject],
+                            annotation.FirstPersonFlag)
                             );
                     }
                     Model.Vrm.FirstPerson = firstPerson;

--- a/Assets/UniVRM0XReader/Runtime/GltfSerialization/FromGltf/GltfStorage.cs
+++ b/Assets/UniVRM0XReader/Runtime/GltfSerialization/FromGltf/GltfStorage.cs
@@ -639,7 +639,7 @@ namespace GltfSerialization
             {
                 sampler = Gltf.samplers[x.sampler];
             }
-            return new ImageTexture(x.name, sampler.FromGltf(), images[x.source], Texture.ColorSpaceTypes.Srgb);
+            return new ImageTexture(x.name ?? "", sampler.FromGltf(), images[x.source], Texture.ColorSpaceTypes.Srgb);
         }
 
         public int MaterialCount => Gltf.materials.Count;
@@ -726,14 +726,14 @@ namespace GltfSerialization
             }
         }
 
-        public BlendShapeManager CreateVrmBlendShape(List<MeshGroup> meshGroups, List<Material> materials)
+        public BlendShapeManager CreateVrmBlendShape(List<MeshGroup> meshGroups, List<Material> materials, List<Node> nodes)
         {
             var gltfVrm = Gltf.extensions.VRM;
             if (gltfVrm.blendShapeMaster != null
                 && gltfVrm.blendShapeMaster.blendShapeGroups != null
                 && gltfVrm.blendShapeMaster.blendShapeGroups.Any())
             {
-                return gltfVrm.blendShapeMaster.FromGltf(meshGroups, materials);
+                return gltfVrm.blendShapeMaster.FromGltf(meshGroups, materials, nodes);
             }
 
             return null;

--- a/Assets/UniVRM0XReader/Runtime/GltfSerialization/FromGltf/ModelFromGltf.cs
+++ b/Assets/UniVRM0XReader/Runtime/GltfSerialization/FromGltf/ModelFromGltf.cs
@@ -39,7 +39,7 @@ namespace GltfSerializationAdapter
                 && gltfVrm.blendShapeMaster.blendShapeGroups != null
                 && gltfVrm.blendShapeMaster.blendShapeGroups.Any())
             {
-                Vrm.BlendShape = gltfVrm.blendShapeMaster.FromGltf(self.MeshGroups, self.Materials);
+                Vrm.BlendShape = gltfVrm.blendShapeMaster.FromGltf(self.MeshGroups, self.Materials, self.Nodes);
             }
 
             // secondary

--- a/Assets/UniVRM0XReader/Runtime/GltfSerialization/FromGltf/VrmBlendShapeFromGltf.cs
+++ b/Assets/UniVRM0XReader/Runtime/GltfSerialization/FromGltf/VrmBlendShapeFromGltf.cs
@@ -37,7 +37,7 @@ namespace GltfSerializationAdapter
             throw new NotImplementedException();
         }
 
-        public static BlendShapeManager FromGltf(this VrmBlendShapeMaster master, List<MeshGroup> meshes, List<Material> materials)
+        public static BlendShapeManager FromGltf(this VrmBlendShapeMaster master, List<MeshGroup> meshes, List<Material> materials, List<Node> nodes)
         {
             var manager = new BlendShapeManager();
             manager.BlendShapeList.AddRange(master.blendShapeGroups.Select(x =>
@@ -47,8 +47,9 @@ namespace GltfSerializationAdapter
                     x.binds.Select(y =>
                     {
                         var group = meshes[y.mesh];
+                        var node = nodes.First(z => z.MeshGroup == group);
                         var blendShapeName = group.Meshes[0].MorphTargets[y.index].Name;
-                        var value = new BlendShapeBindValue(group, blendShapeName, y.weight);
+                        var value = new BlendShapeBindValue(node, blendShapeName, y.weight);
                         return value;
                     }));
                 expression.MaterialValues.AddRange(

--- a/Assets/UniVRM0XReader/Runtime/GltfSerialization/FromGltf/VrmFirstPersonFromGltf.cs
+++ b/Assets/UniVRM0XReader/Runtime/GltfSerialization/FromGltf/VrmFirstPersonFromGltf.cs
@@ -11,7 +11,12 @@ namespace GltfSerializationAdapter
         {
             var self = new FirstPerson();
             self.Annotations.AddRange(fp.meshAnnotations
-                 .Select(x => new FirstPersonMeshAnnotation(meshes[x.mesh], (FirstPersonMeshType)x.firstPersonFlag)));
+                 .Select(x =>
+                 {
+                     var meshGroup = meshes[x.mesh];
+                     var node = nodes.First(y => y.MeshGroup == meshGroup);
+                     return new FirstPersonMeshAnnotation(node, (FirstPersonMeshType)x.firstPersonFlag);
+                 }));
             return self;
         }
     }

--- a/Assets/vrmlib/Runtime/ImportExport/IVrmExporter.cs
+++ b/Assets/vrmlib/Runtime/ImportExport/IVrmExporter.cs
@@ -23,7 +23,7 @@ namespace VrmLib
         void ExportVrmMeta(Vrm src, List<Texture> textures);
         void ExportVrmHumanoid(Dictionary<VrmLib.HumanoidBones, Node> map, List<Node> nodes);
         void ExportVrmMaterialProperties(List<Material> materials, List<Texture> textures);
-        void ExportVrmBlendShape(BlendShapeManager expression, List<MeshGroup> meshes, List<Material> materials);
+        void ExportVrmBlendShape(BlendShapeManager expression, List<MeshGroup> meshes, List<Material> materials, List<Node> nodes);
         void ExportVrmSpringBone(SpringBoneManager springBone, List<Node> nodes);
         void ExportVrmFirstPersonAndLookAt(FirstPerson firstPerson, LookAt lookat, List<MeshGroup> meshes, List<Node> nodes);
         #endregion
@@ -123,7 +123,7 @@ namespace VrmLib
 
             exporter.ExportVrmMaterialProperties(m.Materials, m.Textures);
 
-            exporter.ExportVrmBlendShape(m.Vrm.BlendShape, m.MeshGroups, m.Materials);
+            exporter.ExportVrmBlendShape(m.Vrm.BlendShape, m.MeshGroups, m.Materials, m.Nodes);
 
             exporter.ExportVrmSpringBone(m.Vrm.SpringBone, m.Nodes);
 

--- a/Assets/vrmlib/Runtime/ImportExport/IVrmStorage.cs
+++ b/Assets/vrmlib/Runtime/ImportExport/IVrmStorage.cs
@@ -33,7 +33,7 @@ namespace VrmLib
         string VrmExporterVersion { get; }
         string VrmSpecVersion { get; }
         void LoadVrmHumanoid(List<Node> nodes);
-        BlendShapeManager CreateVrmBlendShape(List<MeshGroup> meshGroups, List<Material> materials);
+        BlendShapeManager CreateVrmBlendShape(List<MeshGroup> meshGroups, List<Material> materials, List<Node> nodes);
         SpringBoneManager CreateVrmSpringBone(List<Node> nodes);
         FirstPerson CreateVrmFirstPerson(List<Node> nodes, List<MeshGroup> meshGroups);
         LookAt CreateVrmLookAt();

--- a/Assets/vrmlib/Runtime/ImportExport/ModelLoader.cs
+++ b/Assets/vrmlib/Runtime/ImportExport/ModelLoader.cs
@@ -106,7 +106,7 @@ namespace VrmLib
                 throw new Exception("CheckVrmHumanoid");
             }
 
-            Vrm.BlendShape = storage.CreateVrmBlendShape(model.MeshGroups, model.Materials);
+            Vrm.BlendShape = storage.CreateVrmBlendShape(model.MeshGroups, model.Materials, model.Nodes);
 
             Vrm.SpringBone = storage.CreateVrmSpringBone(model.Nodes);
 

--- a/Assets/vrmlib/Runtime/Material/Texture.cs
+++ b/Assets/vrmlib/Runtime/Material/Texture.cs
@@ -60,6 +60,10 @@ namespace VrmLib
 
         protected Texture(string name, TextureSampler sampler, ColorSpaceTypes colorSpace, TextureTypes textureType)
         {
+            if (name == null)
+            {
+                throw new ArgumentNullException("name");
+            }
             Name = name;
             Sampler = sampler;
             ColorSpace = colorSpace;

--- a/Assets/vrmlib/Runtime/ModelDiffExtensions.cs
+++ b/Assets/vrmlib/Runtime/ModelDiffExtensions.cs
@@ -454,7 +454,7 @@ namespace VrmLib.Diff
         static bool VrmBlendShapeBindValueEquals(ModelDiffContext context, BlendShapeBindValue lhs, BlendShapeBindValue rhs)
         {
             var equals = true;
-            if (!context.Enter("Mesh").Push(lhs.Mesh, rhs.Mesh, MeshGroupEquals)) equals = false;
+            if (!context.Enter("Node").Push(lhs.Node, rhs.Node, NodeEquals)) equals = false;
             if (!context.Enter("Name").Push(lhs.Name, rhs.Name)) equals = false;
             if (!context.Enter("Value").Push(lhs.Value, rhs.Value)) equals = false;
             return equals;
@@ -473,7 +473,7 @@ namespace VrmLib.Diff
         static bool FirstPersonMeshAnnotationEquals(ModelDiffContext context, FirstPersonMeshAnnotation lhs, FirstPersonMeshAnnotation rhs)
         {
             var equals = true;
-            if (!context.Enter("Mesh").Push(lhs.Mesh, rhs.Mesh, MeshGroupEquals)) equals = false;
+            if (!context.Enter("Node").Push(lhs.Node, rhs.Node, NodeEquals)) equals = false;
             if (!context.Enter("Flag").Push(lhs.FirstPersonFlag, rhs.FirstPersonFlag)) equals = false;
             return equals;
         }

--- a/Assets/vrmlib/Runtime/ModelModifier.cs
+++ b/Assets/vrmlib/Runtime/ModelModifier.cs
@@ -46,37 +46,6 @@ namespace VrmLib
                     node.MeshGroup = dst;
                 }
             }
-
-            // fix VRM
-            if (Model.Vrm != null)
-            {
-                // replace: VrmBlendShape.Mesh
-                if (Model.Vrm.BlendShape != null)
-                {
-                    foreach (var x in Model.Vrm.BlendShape.BlendShapeList)
-                    {
-                        for (int i = 0; i < x.BlendShapeValues.Count; ++i)
-                        {
-                            var v = x.BlendShapeValues[i];
-                            if (src != null && src == v.Mesh)
-                            {
-                                v.Mesh = dst;
-                            }
-                        }
-                    }
-                }
-
-                // replace: VrmFirstPerson.MeshAnnotations
-                if (src != null)
-                {
-                    Model.Vrm.FirstPerson.Annotations.RemoveAll(x => x.Mesh == src);
-                }
-                if (dst != null && !Model.Vrm.FirstPerson.Annotations.Any(x => x.Mesh == dst))
-                {
-                    Model.Vrm.FirstPerson.Annotations.Add(
-                        new FirstPersonMeshAnnotation(dst, FirstPersonMeshType.Auto));
-                }
-            }
         }
 
         /// <summary>
@@ -151,7 +120,36 @@ namespace VrmLib
                 Model.Nodes.Add(dst);
             }
 
-            // TODO: fix VRM
+            // fix VRM
+            if (Model.Vrm != null)
+            {
+                // replace: VrmBlendShape.Mesh
+                if (Model.Vrm.BlendShape != null)
+                {
+                    foreach (var x in Model.Vrm.BlendShape.BlendShapeList)
+                    {
+                        for (int i = 0; i < x.BlendShapeValues.Count; ++i)
+                        {
+                            var v = x.BlendShapeValues[i];
+                            if (src != null && src == v.Node)
+                            {
+                                v.Node = dst;
+                            }
+                        }
+                    }
+                }
+
+                // replace: VrmFirstPerson.MeshAnnotations
+                if (src != null)
+                {
+                    Model.Vrm.FirstPerson.Annotations.RemoveAll(x => x.Node == src);
+                }
+                if (dst != null && !Model.Vrm.FirstPerson.Annotations.Any(x => x.Node == dst))
+                {
+                    Model.Vrm.FirstPerson.Annotations.Add(
+                        new FirstPersonMeshAnnotation(dst, FirstPersonMeshType.Auto));
+                }
+            }            // TODO: fix VRM
             if (Model.Vrm != null)
             {
 

--- a/Assets/vrmlib/Runtime/Node.cs
+++ b/Assets/vrmlib/Runtime/Node.cs
@@ -27,7 +27,7 @@ namespace VrmLib
 
         public Node(string name)
         {
-            UniqueID = s_nextUniqueId ++;
+            UniqueID = s_nextUniqueId++;
             Name = name;
         }
 
@@ -284,7 +284,11 @@ namespace VrmLib
         }
         #endregion
 
+
         public MeshGroup MeshGroup;
+
+        // VRMでは、Meshes.Count==1
+        public Mesh Mesh => MeshGroup?.Meshes?[0];
 
         HumanoidBones? m_bone;
         public HumanoidBones? HumanoidBone

--- a/Assets/vrmlib/Runtime/Vrm/BlendShapeManager.cs
+++ b/Assets/vrmlib/Runtime/Vrm/BlendShapeManager.cs
@@ -9,7 +9,7 @@ namespace VrmLib
         /// <summary>
         /// 対象のMesh(Renderer)
         /// </summary>
-        public MeshGroup Mesh;
+        public Node Node;
 
         /// <summary>
         /// BlendShapeのIndex
@@ -21,9 +21,9 @@ namespace VrmLib
         /// </summary>
         public readonly float Value;
 
-        public BlendShapeBindValue(MeshGroup mesh, string name, float value)
+        public BlendShapeBindValue(Node node, string name, float value)
         {
-            Mesh = mesh;
+            Node = node;
             Name = name;
             Value = value;
         }

--- a/Assets/vrmlib/Runtime/Vrm/FirstPerson.cs
+++ b/Assets/vrmlib/Runtime/Vrm/FirstPerson.cs
@@ -13,13 +13,13 @@ namespace VrmLib
 
     public class FirstPersonMeshAnnotation
     {
-        public readonly MeshGroup Mesh;
+        public readonly Node Node;
 
         public readonly FirstPersonMeshType FirstPersonFlag;
 
-        public FirstPersonMeshAnnotation(MeshGroup mesh, FirstPersonMeshType flag)
+        public FirstPersonMeshAnnotation(Node node, FirstPersonMeshType flag)
         {
-            Mesh = mesh;
+            Node = node;
             FirstPersonFlag = flag;
         }
     }

--- a/Assets/vrmlib/Runtime/Vrm/IAvatarPermission.cs
+++ b/Assets/vrmlib/Runtime/Vrm/IAvatarPermission.cs
@@ -47,7 +47,19 @@ namespace VrmLib
 
         public bool IsAllowedSexualUsage { get; set; }
 
-        public bool IsAllowedCommercialUsage { get => throw new System.NotImplementedException(); }
+        public bool IsAllowedCommercialUsage
+        {
+            get
+            {
+                switch (CommercialUsage)
+                {
+                    case CommercialUsageType.Corporation:
+                    case CommercialUsageType.PersonalCommercial:
+                        return true;
+                }
+                return false;
+            }
+        }
 
         public CommercialUsageType CommercialUsage { get; set; }
 

--- a/Assets/vrmlib/Runtime/Vrm/IRedistributionLicense.cs
+++ b/Assets/vrmlib/Runtime/Vrm/IRedistributionLicense.cs
@@ -46,7 +46,7 @@ namespace VrmLib
     {
         public DistributionLicenseType License
         {
-            get => throw new NotImplementedException();
+            get => DistributionLicenseType.Redistribution_Prohibited;
         }
 
         public CreditNotationType CreditNotation { get; set; }


### PR DESCRIPTION
https://github.com/vrm-c/vrm-specification/pull/106

を実装。
Unity的にはMeshではなくRendererを指していて、これはGltfのNodeに相当する。